### PR TITLE
Fix 2 page display for 1 page content.

### DIFF
--- a/ngPrint.css
+++ b/ngPrint.css
@@ -6,11 +6,11 @@
 
 @media print {
     body * {
-        visibility:hidden;
+        display:none;
     }
 
     #printSection, #printSection * {
-        visibility:visible;
+        display: inline;
     }
 
     #printSection {


### PR DESCRIPTION
visibility:hidden only hides the content, it still takes place on the page. In some cases, the displayed content might be only taking 1 page but the hidden content makes it take 2 pages.
So to solve this, we remove the content from the print media altogether by using display:none instead of visibility:hidden.
