### PR TITLE
Google Chrome compatibility in print preview

### DIFF
--- a/ngPrint.js
+++ b/ngPrint.js
@@ -30,6 +30,7 @@
         function printElement(elem) {
             // clones the element you want to print
             var domClone = elem.cloneNode(true);
+            printSection.innerHTML = '';
             printSection.appendChild(domClone);
             window.print();
         }


### PR DESCRIPTION
window.onafterprint is not supported by some browsers, especially Google Chrome.
In Chrome, if you print something twice, the same content is displayed twice in the print preview.
You print thrice, it is displayed thrice in print preview.
To solve this, printSection.innerHTML is set to an empty string every time content is loaded in the print section.
